### PR TITLE
refactor: up `main.go` err handling flow

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,12 +7,13 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
+
 	"production-go-api-template/api/resource"
 	"production-go-api-template/api/router"
 	"production-go-api-template/api/router/middleware"
 	"production-go-api-template/config"
 	"production-go-api-template/pkg/logger"
-	"syscall"
 
 	"github.com/rs/zerolog"
 	"gorm.io/driver/sqlite"
@@ -65,31 +66,32 @@ func main() {
 		IdleTimeout:  c.Server.TimeoutIdle,
 	}
 
-	closed := make(chan struct{})
+	done := make(chan struct{})
 
 	go func() {
-		sigint := make(chan os.Signal, 1)
-		signal.Notify(sigint, os.Interrupt, syscall.SIGTERM)
-		<-sigint
-
-		l.Info().Msgf("Shutting down server %v", s.Addr)
-
-		ctx, cancel := context.WithTimeout(context.Background(), c.Server.TimeoutIdle)
-		defer cancel()
-
-		if err := s.Shutdown(ctx); err != nil {
-			l.Error().Err(err).Msg("Server shutdown failure")
+		l.Info().Msgf("Starting server %v", s.Addr)
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			l.Fatal().Err(err).Msg("Server startup failure")
 		}
-
-		close(closed)
+		close(done)
 	}()
 
-	l.Info().Msgf("Starting server %v", s.Addr)
-	if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		l.Fatal().Err(err).Msg("Server startup failure")
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	<-sigChan
+
+	l.Info().Msgf("Shutting down server %v", s.Addr)
+
+	ctx, cancel := context.WithTimeout(context.Background(), c.Server.TimeoutIdle)
+	defer cancel()
+
+	if err := s.Shutdown(ctx); err != nil {
+		l.Fatal().Err(err).Msg("Server shutdown failure")
 	}
 
-	<-closed
+	<-done
+
 	l.Info().Msgf("Server shutdown successfully")
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,11 +69,11 @@ func main() {
 	done := make(chan struct{})
 
 	go func() {
+		defer close(done)
 		l.Info().Msgf("Starting server %v", s.Addr)
 		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			l.Fatal().Err(err).Msg("Server startup failure")
 		}
-		close(done)
 	}()
 
 	sigChan := make(chan os.Signal, 1)


### PR DESCRIPTION
This is a very small adjustment to aid code readability. The control flow of the main function is correct, but I thought that there could be a small "rewording" of it.

First, I modified the names of `sigint` channel and the `closed` channel to `sigChan` and `done` to follow some de facto Go conventions (at least what I've seen). Then I swapped the places of the signal listening and shutdown logic with `ListenAndServe` call. Reading the code becomes a little more intuitive, because it is now obvious that there is a blocking call before the server exits on a signal termination, as indicated by `<-sigChan` being in the main routine.

Further improvements to the control flow in the future may include using a wait group. However, since this is a minimal template, that is just an aside.

Thank you for considering my PR.